### PR TITLE
Fix BaseService logging

### DIFF
--- a/app/services/base_service.py
+++ b/app/services/base_service.py
@@ -24,7 +24,7 @@ class BaseService(Generic[ModelType]):
             )
             logger.info(f"Retrieved {len(items)} items (total: {total})")
         except Exception as e:
-            logger.exception("Failed to fetch paginated data" + e)
+            logger.exception("Failed to fetch paginated data: %s", e)
             raise
 
         if self._response_schema and items:


### PR DESCRIPTION
## Summary
- fix bad string concatenation in BaseService exception logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401ca5e408832abf7c438546960d03