### PR TITLE
Fix validators and seed logic

### DIFF
--- a/app/api/schemas/client_schema.py
+++ b/app/api/schemas/client_schema.py
@@ -2,7 +2,6 @@ import re
 from typing import Optional, List
 
 from pydantic import EmailStr, Field, model_validator, constr, field_validator
-from pydantic import validator
 
 from app.api.schemas.base_schema import (
     BaseSchema,

--- a/app/api/schemas/vessel_schema.py
+++ b/app/api/schemas/vessel_schema.py
@@ -62,13 +62,13 @@ class VesselUpdate(BaseSchema):
     max_speed: Optional[float] = Field(None, gt=0)
     current_location: Optional[str] = Field(None, min_length=1, max_length=50)
 
-    @classmethod
+    @model_validator(mode="before")
     def check_not_empty(cls, data: dict) -> dict:
         if not any(data.values()):
             raise ValueError("At least one field must be updated")
         return data
 
-    @classmethod
+    @field_validator("status")
     def validate_status(cls, v: Optional[str]) -> Optional[str]:
         if v is None:
             return v

--- a/app/infrastructure/seed_data.py
+++ b/app/infrastructure/seed_data.py
@@ -113,11 +113,6 @@ async def insert_initial_data(session: AsyncSession):
 
     await session.commit()
 
-    # Prevent duplicate seeding
-    result = await session.execute(select(Client).limit(1))
-    if result.scalars().first():
-        return
-
     # CLIENT
     client = Client(
         company_name="Acme Corp",

--- a/app/services/base_service.py
+++ b/app/services/base_service.py
@@ -24,7 +24,7 @@ class BaseService(Generic[ModelType]):
             )
             logger.info(f"Retrieved {len(items)} items (total: {total})")
         except Exception as e:
-            logger.exception("Failed to fetch paginated data: %s", e)
+            logger.exception("Failed to fetch paginated data", exc_info=e)
             raise
 
         if self._response_schema and items:


### PR DESCRIPTION
## Summary
- log exceptions properly in BaseService
- add decorators for VesselUpdate validators
- remove unused import in client schema
- simplify duplicate check in seed data script

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402195f570832a8b7234bb0ca61574